### PR TITLE
Remove duplicate "requirements" attribute inmanifest.json

### DIFF
--- a/custom_components/miheater/manifest.json
+++ b/custom_components/miheater/manifest.json
@@ -6,7 +6,6 @@
   "requirements": ["python-miio>=0.5.4"],
   "dependencies": [],
   "codeowners": [],
-  "requirements": ["python-miio>=0.5.0"],
   "iot_class": "local_polling",
   "version": "1.0.0"
 }


### PR DESCRIPTION
`requirements` attribute already appears on line 6 with a different value